### PR TITLE
removing envgen~ alias

### DIFF
--- a/gui/envgen.c
+++ b/gui/envgen.c
@@ -4,7 +4,7 @@
 
 #define DEBUG(x)
 //#define DEBUG(x) x
-/* ------------------------ envgen~ ----------------------------- */
+/* ------------------------ envgen ----------------------------- */
 
 #define NONE    0
 #define ATTACK  1
@@ -339,7 +339,6 @@ void envgen_setup(void)
                              A_GIMME,
                              0);
 
-    class_addcreator((t_newmethod)envgen_new,gensym("envgen~"),A_GIMME,0);
     class_addfloat(envgen_class, envgen_float);
 
     class_addbang(envgen_class,envgen_bang);


### PR DESCRIPTION
I'm doing this cause it is pointless in a separately compiled binary setup

By the way, I don't think anybody knows about this, but envgen has an alias: envgen~

The fact that it has two names that are so similar is weird and could be thought of some sort of bug. And the thing is also that I don't believe anybody knows about it p I only lerned about it by checking the source code. And the fact is that you can't actually load the object as envgen~, unless you load it as [envgen] first - so, it's quite pointless, because it is an alias you can't actually use as you always need to load the object as [envgen] anyway, and the reason why I believe no one ever used this object as [envgen~].

If the case was that of a single binary pack, then it'd be different, as when you loaded the library you'd have access to all aliases and then load this as [envgen~] if you wished so, but that wasn't the case in Pd Extended and it is not the case now in Vanilla via deken... so... best thing is to just remove this from the code. 